### PR TITLE
FEST-484 Added nonvarags alternatives to Collections

### DIFF
--- a/src/main/java/org/fest/util/Collections.java
+++ b/src/main/java/org/fest/util/Collections.java
@@ -72,7 +72,6 @@ public final class Collections {
    * @since 1.2.2
    */
   public static <T> List<T> list(T first, T second) {
-    if (first == null || second == null) return null;
     List<T> list = new ArrayList<T>();
     list.add(first);
     list.add(second);
@@ -117,7 +116,6 @@ public final class Collections {
    * @since 1.2.2
    */
   public static <T> Set<T> set(T first, T second) {
-    if (first == null || second == null) return null;
     Set<T> set = new LinkedHashSet<T>();
     set.add(first);
     set.add(second);

--- a/src/test/java/org/fest/util/Collections_list_Test.java
+++ b/src/test/java/org/fest/util/Collections_list_Test.java
@@ -44,14 +44,6 @@ public class Collections_list_Test {
 	assertNull(Collections.list(nullString));
   }
 
-  @Test public void should_return_null_if_first_element_is_null() {
-	assertNull(Collections.list(null, "Two"));
-  }
-
-  @Test public void should_return_null_if_second_element_is_null() {
-	assertNull(Collections.list("One", null));
-  }
-
   @Test public void should_return_empty_List_if_array_is_empty() {
     assertTrue(Collections.list(new Object[0]).isEmpty());
   }

--- a/src/test/java/org/fest/util/Collections_set_Test.java
+++ b/src/test/java/org/fest/util/Collections_set_Test.java
@@ -56,12 +56,4 @@ public class Collections_set_Test {
 	String nullString = null;
 	assertNull(Collections.set(nullString));
   }
-
-  @Test public void should_return_null_if_second_element_is_null() {
-	assertNull(Collections.set("one", null));
-  }
-
-  @Test public void should_return_null_if_first_element_is_null() {
-	assertNull(Collections.set(null, "two"));
-  }
 }


### PR DESCRIPTION
This avoids the generic varargs warnings when users are
trying to create lists/sets (with one or two elements)
for types with type parameters.
